### PR TITLE
Add Time Formatting Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ See the list below for info:
 - `segmented` -> Displays the remainder as `20:22:13:49`
 - `segmented2` -> Displays the remainder as `20d:22h:13m:49s`
 - `segmented3` -> Displays the remainder as `20-22-13-49`
+- `dayFocused` -> Displays the remainder as `Only 20 days left!`
 
 ## Credits:
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ See the list below for info:
 - `segmented` -> Displays the remainder as `20:22:13:49`
 - `segmented2` -> Displays the remainder as `20d:22h:13m:49s`
 - `segmented3` -> Displays the remainder as `20-22-13-49`
-- `written` -> Displays the remainder as `20 days, 22 hours, 13 minutes & 49 seconds` (needs test)
 
 ## Credits:
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ npm install discord-rich-presence
 - Under "Rich Presence", click on "Art Assets" and upload the `totk.png` and `clock.png` files from the `assets` folder.
 - Note down the "Client ID" at the top of the page.
 5. Replace the `clientId` variable in `config.json`, which is stored in the `assets` folder with the client ID you just noted down.
-6. Run the program by executing the following command:
+6. Set the format of the remaining time as you wish. Look down below for more information on available formats.
+7. Run the program by executing the following command:
 
 ```
 node rpc.js
@@ -37,6 +38,16 @@ node rpc.js
 
 That's it! The TOTK Countdown RPC should now be running and displaying your Rich Presence status in Discord.
 
+## Available Formats
+
+TOTK-Countdown-RPC supports a few formats to display the remaining time as.
+See the list below for info:
+
+- `default` -> Displays the remainder as `20d 22h 13m 49s`
+- `segmented` -> Displays the remainder as `20:22:13:49`
+- `segmented2` -> Displays the remainder as `20d:22h:13m:49s`
+- `segmented3` -> Displays the remainder as `20-22-13-49`
+- `written` -> Displays the remainder as `20 days, 22 hours, 13 minutes & 49 seconds` (needs test)
 
 ## Credits:
 

--- a/RPC.js
+++ b/RPC.js
@@ -1,5 +1,6 @@
 const clientConfig = require('./assets/config.json');
 const clientId = `${clientConfig.clientId}`;
+const clientFormat = `${clientConfig.format}`;
 const client = require('discord-rich-presence')(clientId);
 
 // Set up the target date and get the respective time.
@@ -25,20 +26,82 @@ let update = setInterval(function() {
 
 function setRpc(days, hours, minutes, seconds) {
     try {
-        client.updatePresence({
-            details: "Waiting for Tears of the Kingdom...",
-            state: `${days}d ${hours}h ${minutes}m ${seconds}s left!`,
-            largeImageKey: "totk",
-            largeImageText: "Tears of the Kingdom",
-            smallImageKey: "clock",
-            smallImageText: `Time left: ${days}d ${hours}h ${minutes}m `,
-            buttons: [
-                {
-                    label: "Watch the countdown",
-                    url: "https://www.timeanddate.com/countdown/generic?iso=20230512T00&p0=1309&msg=Time+until+Tears+of+the+Kingdom+releases...&ud=1&font=slab&csz=1#"
-                }
-            ]
-        });
+        if (clientFormat === "segmented") {
+            client.updatePresence({
+                details: "Waiting for Tears of the Kingdom...",
+                state: `${days}:${hours}:${minutes}:${seconds} left!`,
+                largeImageKey: "totk",
+                largeImageText: "Tears of the Kingdom",
+                smallImageKey: "clock",
+                smallImageText: `Time left: ${days}:${hours}:${minutes}`,
+                buttons: [
+                    {
+                        label: "Watch the countdown",
+                        url: "https://www.timeanddate.com/countdown/generic?iso=20230512T00&p0=1309&msg=Time+until+Tears+of+the+Kingdom+releases...&ud=1&font=slab&csz=1#"
+                    }
+                ]
+            });
+        } else if (clientFormat === "segmented2") {
+            client.updatePresence({
+                details: "Waiting for Tears of the Kingdom...",
+                state: `${days}d:${hours}h:${minutes}m:${seconds}s left!`,
+                largeImageKey: "totk",
+                largeImageText: "Tears of the Kingdom",
+                smallImageKey: "clock",
+                smallImageText: `Time left: ${days}d:${hours}h${minutes}m`,
+                buttons: [
+                    {
+                        label: "Watch the countdown",
+                        url: "https://www.timeanddate.com/countdown/generic?iso=20230512T00&p0=1309&msg=Time+until+Tears+of+the+Kingdom+releases...&ud=1&font=slab&csz=1#"
+                    }
+                ]
+            });
+        } else if (clientFormat === "segmented3") {
+            client.updatePresence({
+                details: "Waiting for Tears of the Kingdom...",
+                state: `${days}-${hours}-${minutes}-${seconds} left!`,
+                largeImageKey: "totk",
+                largeImageText: "Tears of the Kingdom",
+                smallImageKey: "clock",
+                smallImageText: `Time left: ${days}-${hours}-${minutes}m`,
+                buttons: [
+                    {
+                        label: "Watch the countdown",
+                        url: "https://www.timeanddate.com/countdown/generic?iso=20230512T00&p0=1309&msg=Time+until+Tears+of+the+Kingdom+releases...&ud=1&font=slab&csz=1#"
+                    }
+                ]
+            });
+        } else if (clientFormat === "written") {
+            client.updatePresence({
+                details: "Waiting for Tears of the Kingdom...",
+                state: `${days} days, ${hours} hours, ${minutes} minutes & ${seconds} seconds left!`,
+                largeImageKey: "totk",
+                largeImageText: "Tears of the Kingdom",
+                smallImageKey: "clock",
+                smallImageText: `Time left: ${days} days, ${hours} hours & ${minutes} minutes`,
+                buttons: [
+                    {
+                        label: "Watch the countdown",
+                        url: "https://www.timeanddate.com/countdown/generic?iso=20230512T00&p0=1309&msg=Time+until+Tears+of+the+Kingdom+releases...&ud=1&font=slab&csz=1#"
+                    }
+                ]
+            });
+        } else {
+            client.updatePresence({
+                details: "Waiting for Tears of the Kingdom...",
+                state: `${days}d ${hours}h ${minutes}m ${seconds}s left!`,
+                largeImageKey: "totk",
+                largeImageText: "Tears of the Kingdom",
+                smallImageKey: "clock",
+                smallImageText: `Time left: ${days}d ${hours}h ${minutes}m `,
+                buttons: [
+                    {
+                        label: "Watch the countdown",
+                        url: "https://www.timeanddate.com/countdown/generic?iso=20230512T00&p0=1309&msg=Time+until+Tears+of+the+Kingdom+releases...&ud=1&font=slab&csz=1#"
+                    }
+                ]
+            });
+        }
     } catch (error) {
         console.error(error);
     }

--- a/RPC.js
+++ b/RPC.js
@@ -17,20 +17,21 @@ let update = setInterval(function() {
     let days = Math.floor(timeUntil / (1000 * 60 * 60 * 24));
     let hours = Math.floor((timeUntil % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
     let minutes = Math.floor((timeUntil % (1000 * 60 * 60)) / (1000 * 60));
+    let seconds = Math.floor((timeUntil % (1000 * 60)) / 1000);
 
     // console.log(`${days}d ${hours}h ${minutes}m`);
-    setRpc(days, hours, minutes);
+    setRpc(days, hours, minutes, seconds);
 }, 1000);
 
-function setRpc(days, hours, minutes) {
+function setRpc(days, hours, minutes, seconds) {
     try {
         client.updatePresence({
             details: "Waiting for Tears of the Kingdom...",
-            state: `${days}d ${hours}h ${minutes}m left!`,
+            state: `${days}d ${hours}h ${minutes}m ${seconds}s left!`,
             largeImageKey: "totk",
             largeImageText: "Tears of the Kingdom",
             smallImageKey: "clock",
-            smallImageText: `Time left: ${days}d ${hours}h ${minutes}m`,
+            smallImageText: `Time left: ${days}d ${hours}h ${minutes}m `,
             buttons: [
                 {
                     label: "Watch the countdown",

--- a/RPC.js
+++ b/RPC.js
@@ -48,7 +48,7 @@ function setRpc(days, hours, minutes, seconds) {
                 largeImageKey: "totk",
                 largeImageText: "Tears of the Kingdom",
                 smallImageKey: "clock",
-                smallImageText: `Time left: ${days}d:${hours}h${minutes}m`,
+                smallImageText: `Time left: ${days}d:${hours}h:${minutes}m`,
                 buttons: [
                     {
                         label: "Watch the countdown",
@@ -63,22 +63,7 @@ function setRpc(days, hours, minutes, seconds) {
                 largeImageKey: "totk",
                 largeImageText: "Tears of the Kingdom",
                 smallImageKey: "clock",
-                smallImageText: `Time left: ${days}-${hours}-${minutes}m`,
-                buttons: [
-                    {
-                        label: "Watch the countdown",
-                        url: "https://www.timeanddate.com/countdown/generic?iso=20230512T00&p0=1309&msg=Time+until+Tears+of+the+Kingdom+releases...&ud=1&font=slab&csz=1#"
-                    }
-                ]
-            });
-        } else if (clientFormat === "written") {
-            client.updatePresence({
-                details: "Waiting for Tears of the Kingdom...",
-                state: `${days} days, ${hours} hours, ${minutes} minutes & ${seconds} seconds left!`,
-                largeImageKey: "totk",
-                largeImageText: "Tears of the Kingdom",
-                smallImageKey: "clock",
-                smallImageText: `Time left: ${days} days, ${hours} hours & ${minutes} minutes`,
+                smallImageText: `Time left: ${days}-${hours}-${minutes}`,
                 buttons: [
                     {
                         label: "Watch the countdown",

--- a/RPC.js
+++ b/RPC.js
@@ -71,6 +71,21 @@ function setRpc(days, hours, minutes, seconds) {
                     }
                 ]
             });
+        } else if (clientFormat === "dayFocused") {
+            client.updatePresence({
+                details: "Waiting for Tears of the Kingdom...",
+                state: `Only ${days} days left!`,
+                largeImageKey: "totk",
+                largeImageText: "Tears of the Kingdom",
+                smallImageKey: "clock",
+                smallImageText: `Time left: ${days} days`,
+                buttons: [
+                    {
+                        label: "Watch the countdown",
+                        url: "https://www.timeanddate.com/countdown/generic?iso=20230512T00&p0=1309&msg=Time+until+Tears+of+the+Kingdom+releases...&ud=1&font=slab&csz=1#"
+                    }
+                ]
+            });
         } else {
             client.updatePresence({
                 details: "Waiting for Tears of the Kingdom...",

--- a/assets/config.json
+++ b/assets/config.json
@@ -1,3 +1,4 @@
 {
-  "clientId": ""
+  "clientId": "",
+  "format": "default"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "totk-countdown-rpc",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "dependencies": {
     "discord-rich-presence": "^0.0.8"
   }


### PR DESCRIPTION
The PR adds the ability to choose between different options to format the remainder time in the Rich Presence Module.

- `default` -> As it has been before: `20d 19h 34m 29s left!`
- `segmented` -> `20:19:34:29 left!`
- `segmented2` -> `20d:19h:34m:29s left!`
- `segmented3` -> `20-19-34-29 left!`
- `dayFocused` -> `Only 20 days left!`